### PR TITLE
Added Graylog

### DIFF
--- a/raw/log4j affected apps.csv
+++ b/raw/log4j affected apps.csv
@@ -61,6 +61,7 @@ Dynatrace,Dynatrace Synthetic Chromium,https://community.dynatrace.com/t5/Dynatr
 Forcepoint,Security manager,https://support.forcepoint.com/s/article/CVE-2021-44228-Java-log4j-vulnerability-mitigation-with-NGFW-Security-Management-Center
 Forcepoint,DLP Manager,https://support.forcepoint.com/s/article/CVE-2021-44228-Java-log4j-vulnerability-mitigation-with-NGFW-Security-Management-Center
 GoAnywhere,GoAnywhere,https://www.goanywhere.com/cve-2021-44228-goanywhere-mitigation-steps
+Graylog,Graylog,https://www.graylog.org/post/graylog-update-for-log4j
 JAMF,JAMF Pro,https://community.jamf.com/t5/jamf-pro/third-party-security-issue/td-p/253740
 n-able,Risk Intelligence,https://www.n-able.com/security-and-privacy/apache-log4j-vulnerability
 n-able,N-able RMM,https://www.n-able.com/security-and-privacy/apache-log4j-vulnerability


### PR DESCRIPTION
Graylog versions between 1.2.0 and  4.2.2 are vulnerable: https://www.graylog.org/post/graylog-update-for-log4j 